### PR TITLE
Preserve full path when redirecting to login

### DIFF
--- a/products/frontend/src/routes/SessionCheck/index.tsx
+++ b/products/frontend/src/routes/SessionCheck/index.tsx
@@ -17,7 +17,8 @@ const SessionCheck: FC = () => {
     onError: () => {
       // sessionが無効な場合、ログインページへリダイレクト
       // その際、現在のパスをredirectクエリパラメータとして渡す
-      navigate(`/login?redirect=${encodeURIComponent(location.pathname)}`, { replace: true });
+      const currentPath = `${location.pathname}${location.search}${location.hash}`;
+      navigate(`/login?redirect=${encodeURIComponent(currentPath)}`, { replace: true });
     },
   });
 


### PR DESCRIPTION
### Motivation
- When session is invalid we should redirect the user to `/login` with the full original path (including query string and hash) so that after login they return to the exact location they were at.

### Description
- Update `SessionCheck` to build `currentPath` using `location.pathname`, `location.search`, and `location.hash`, and navigate to `/login?redirect=${encodeURIComponent(currentPath)}` instead of only encoding `location.pathname` in `products/frontend/src/routes/SessionCheck/index.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975f4625a3083288a46d5c3f814e9f8)